### PR TITLE
__dirname instead of ./ for relative paths

### DIFF
--- a/ETHController_template.hbs
+++ b/ETHController_template.hbs
@@ -1,4 +1,4 @@
-let Connector = require("./GenericETHConnector");
+let Connector = require(__dirname+"/GenericETHConnector");
 let fs = require("fs");
 
 /**
@@ -12,8 +12,8 @@ class Controller{
     * @description initializes the connector, which will interact with SmartContract via web3
     * */
     constructor(){
-        this.config = JSON.parse(fs.readFileSync("./config.json"));
-        this.connector = new Connector("./contract.json", this.config);
+        this.config = JSON.parse(fs.readFileSync(__dirname+"/config.json"));
+        this.connector = new Connector(__dirname+"/contract.json", this.config);
     }
 
 {{#each abi}}

--- a/GenericETHConnector.js
+++ b/GenericETHConnector.js
@@ -33,7 +33,7 @@ class Connector{
         try {
             let data = fs.readFileSync(contract_path);
             let contract_schema = JSON.parse(data);
-            this.contract = new web3.eth.Contract(contract_schema.abi, conf.eth.whitelist_contract.contract_address);
+            this.contract = new web3.eth.Contract(contract_schema.abi, conf.eth.whitelist_contract && conf.eth.whitelist_contract.contract_address);
         } catch (err) {
             this.contract =null;
             console.log(err);

--- a/GenericETHConnector.js
+++ b/GenericETHConnector.js
@@ -1,4 +1,4 @@
-const conf = require("./config.json");
+const conf = require(__dirname+"/config.json");
 let fs = require("fs");
 const Web3 = require("web3");
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ let path = require("path");
 const program = require('commander');
 const package = JSON.parse(fs.readFileSync(path.resolve(__dirname, './package.json')));
 
-const ETHConnectorGenerator = require('./ETHConnectorGenerator');
+const ETHConnectorGenerator = require(__dirname+'/ETHConnectorGenerator');
 
 program
     .version(package.version)

--- a/tests/ETHConnectorGenerator.spec.js
+++ b/tests/ETHConnectorGenerator.spec.js
@@ -1,14 +1,14 @@
 'use strict';
-const utils = require("./utils");
+const utils = require(__dirname+"utils");
 const fs = require("fs");
 const assert = require('chai').assert;
 
 let schema = [
     {
         className: "ETHConnectorGenerator",
-        classPath: "../ETHConnectorGenerator",
+        classPath: __dirname+"/../ETHConnectorGenerator",
         call_instance(cls){
-            let generator = new cls("./tests/samples/test_config.json");
+            let generator = new cls(__dirname+"/tests/samples/test_config.json");
             generator.init();
             generator.process();
             return generator;
@@ -17,7 +17,7 @@ let schema = [
             it(`Generated ETH connector controller output class matches the sample output file contents`, () => {
                 assert.equal(
                     instance.controller_class_code,
-                    fs.readFileSync("./tests/samples/eth_connector/Controller.js"),
+                    fs.readFileSync(__dirname+"/tests/samples/eth_connector/Controller.js"),
                 );
             });
         },

--- a/tests/samples/eth_connector/Controller.js
+++ b/tests/samples/eth_connector/Controller.js
@@ -1,4 +1,4 @@
-let Connector = require("./GenericETHConnector");
+let Connector = require(__dirname+"/GenericETHConnector");
 let fs = require("fs");
 
 /**
@@ -12,8 +12,8 @@ class Controller{
     * @description initializes the connector, which will interact with SmartContract via web3
     * */
     constructor(){
-        this.config = JSON.parse(fs.readFileSync("./config.json"));
-        this.connector = new Connector("./contract.json", this.config);
+        this.config = JSON.parse(fs.readFileSync(__dirname+"/config.json"));
+        this.connector = new Connector(__dirname+"/contract.json", this.config);
     }
 
     /**

--- a/tests/samples/eth_connector/GenericETHConnector.js
+++ b/tests/samples/eth_connector/GenericETHConnector.js
@@ -33,7 +33,7 @@ class Connector{
         try{
             let data = fs.readFileSync(contract_path);
             let contract_schema = JSON.parse(data);
-            this.contract = new web3.eth.Contract(contract_schema.abi, conf.eth.whitelist_contract.contract_address);
+            this.contract = new web3.eth.Contract(contract_schema.abi, conf.eth.whitelist_contract && conf.eth.whitelist_contract.contract_address);
         }catch (err) {
             this.contract =null;
             console.log(err);

--- a/tests/samples/eth_connector/GenericETHConnector.js
+++ b/tests/samples/eth_connector/GenericETHConnector.js
@@ -1,4 +1,4 @@
-const conf = require("./config.json");
+const conf = require(__dirname+"/config.json");
 let fs = require("fs");
 const Web3 = require("web3");
 


### PR DESCRIPTION
TIL that `./` is only relative to the directory from which you ran the `node` command in your terminal window and that `__dirname` the directory in which the currently executing script resides, which is what we want when someone takes this generated code and moves it somewhere away from wherever they execute `node` and expect it to work the same way.

https://stackoverflow.com/questions/8131344/what-is-the-difference-between-dirname-and-in-node-js

Update: Also found and fixed bug relating to conf.eth.whitelist_contract being undefined.